### PR TITLE
Updated config.plist (HDMI through USB-C)

### DIFF
--- a/config.plist
+++ b/config.plist
@@ -1411,7 +1411,7 @@
 				<key>SystemAudioVolume</key>
 				<data>Rg==</data>
 				<key>boot-args</key>
-				<string>keepsyms=1 -wegnoegpu</string>
+				<string>keepsyms=1 -wegnoegpu agdpmod=vit9696</string>
 				<key>csr-active-config</key>
 				<data>AAAAAA==</data>
 				<key>prev-lang:kbd</key>


### PR DESCRIPTION
Add bootargs to use the HDMI through a USB-C adapter (I use Satechi USB-C Multi-Port adapter for this purpose, [ST-SCMA2S] ) it's working without problems. 
The native HDMI output don't. (apparently it's linked to the dGPU, who is disabled).